### PR TITLE
Add simple Axum REST API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # Codex_test
-chatGPT(Codex) test
+
+This repository contains a minimal Axum based REST API example.
+
+## Running the server
+
+```
+cargo run -p rest_api
+```
+
+The server exposes two endpoints:
+
+- `GET /sample/getHello` returns a simple greeting message.
+- `POST /sample/postContent` accepts JSON `{ "content": "..." }` and echoes it back.
+
+## Running tests
+
+```
+cargo test -p rest_api
+```

--- a/rest_api/Cargo.toml
+++ b/rest_api/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rest_api"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+axum = "0.6"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/rest_api/src/main.rs
+++ b/rest_api/src/main.rs
@@ -1,0 +1,83 @@
+use axum::{routing::{get, post}, Router, Json};
+use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
+
+#[derive(Serialize)]
+struct HelloResponse {
+    message: String,
+}
+
+async fn get_hello() -> Json<HelloResponse> {
+    Json(HelloResponse {
+        message: "Hello".to_string(),
+    })
+}
+
+#[derive(Deserialize)]
+struct ContentRequest {
+    content: String,
+}
+
+#[derive(Serialize)]
+struct ContentResponse {
+    received: String,
+}
+
+async fn post_content(Json(payload): Json<ContentRequest>) -> Json<ContentResponse> {
+    Json(ContentResponse {
+        received: payload.content,
+    })
+}
+
+#[tokio::main]
+async fn main() {
+    let app = Router::new()
+        .route("/sample/getHello", get(get_hello))
+        .route("/sample/postContent", post(post_content));
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    println!("Listening on {}", addr);
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+
+    #[tokio::test]
+    async fn test_get_hello() {
+        let app = Router::new().route("/sample/getHello", get(get_hello));
+
+        let response = app
+            .oneshot(Request::builder().uri("/sample/getHello").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_post_content() {
+        let app = Router::new().route("/sample/postContent", post(post_content));
+
+        let payload = serde_json::json!({"content": "data"});
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/sample/postContent")
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+}


### PR DESCRIPTION
## Summary
- create `rest_api` binary crate
- implement GET and POST endpoints using Axum
- add unit tests
- document how to run server and tests

## Testing
- `cargo test` *(fails: failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6848c8740520832c8772820208ea7fda